### PR TITLE
Fixes compilation errors when using project as rebar dependency.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,4 +2,3 @@
     {procket, ".*", {git, "git://github.com/msantos/procket.git", "master"}},
     {pkt, ".*", {git, "git://github.com/msantos/pkt.git", "master"}}
     ]}.
-{erl_opts, [{i, "deps/pkt/include"}]}.

--- a/src/gen_icmp.erl
+++ b/src/gen_icmp.erl
@@ -31,7 +31,7 @@
 -module(gen_icmp).
 -behaviour(gen_server).
 -include_lib("kernel/include/inet.hrl").
--include("pkt.hrl").
+-include_lib("pkt/include/pkt.hrl").
 
 -define(SERVER, ?MODULE).
 

--- a/src/ptun.erl
+++ b/src/ptun.erl
@@ -49,7 +49,7 @@
 %% 
 
 -module(ptun).
--include("pkt.hrl").
+-include_lib("pkt/include/pkt.hrl").
 
 -export([client/2, server/2]).
 

--- a/src/tracert.erl
+++ b/src/tracert.erl
@@ -38,7 +38,7 @@
 -module(tracert).
 -behaviour(gen_server).
 
--include("pkt.hrl").
+-include_lib("pkt/include/pkt.hrl").
 
 -export([
         host/1, host/2, host/3,


### PR DESCRIPTION
Please review the fix that removes explicit include directories configuration in rebar.config and uses include_lib to include pkt.hrl.

Without the fix gen_icmp could not be used as rebar dependency, since rebar will download all deps (including gen_icmp deps) into <ROOT>/deps and gen_icmp without the patch expects dependency to be available at <ROOT>/deps/gen_icmp/deps
