### PR TITLE
Fixed 'gen_icmp.app.src'

### DIFF
--- a/src/gen_icmp.app.src
+++ b/src/gen_icmp.app.src
@@ -1,5 +1,6 @@
 {application, gen_icmp,
-    [
-    {description, "Interface to ICMP sockets"},
-    {vsn, "0.03"}
-    ]}.
+    [{description, "Interface to ICMP sockets"},
+     {vsn, "0.03"},
+     {registered, []},
+     {applications, [kernel, stdlib]}
+]}.


### PR DESCRIPTION
Hello, '.app.src' file was missing a couple of fields, required by `systools:make_script/2`, now everything seems to be fine.
