### PR TITLE
Fix CaseClauseError in ping_loop/3 on ICMP error with mismatched DA

### DIFF
--- a/src/gen_icmp.erl
+++ b/src/gen_icmp.erl
@@ -1363,6 +1363,8 @@ ping_loop(
                                 {Id, Seq, TTL, undefined}, Payload}
                             | Acc
                         ]};
+                    {value, _NoMatch, _NHosts} ->
+                        {Hosts, Acc};
                     false ->
                         {Hosts, Acc}
                 end,
@@ -1396,7 +1398,6 @@ ping_loop(
                 ?ICMP6_ECHO_REQUEST:8, 0:8, _Checksum2:16, Id:16, Seq:16, _/binary>> = Data} ->
             <<_ICMPHeader:8/bytes, Payload/binary>> = Data,
             DA = {DA1, DA2, DA3, DA4, DA5, DA6, DA7, DA8},
-            {value, {ok, Addr, DA, Seq}, Hosts2} = lists:keytake(Seq, 4, Hosts),
             {Hosts2, Result} =
                 case lists:keytake(Seq, 4, Hosts) of
                     {value, {ok, Addr, DA, Seq}, NHosts} ->
@@ -1405,6 +1406,8 @@ ping_loop(
                                 {Id, Seq, TTL, undefined}, Payload}
                             | Acc
                         ]};
+                    {value, _NoMatch, _NHosts} ->
+                        {Hosts, Acc};
                     false ->
                         {Hosts, Acc}
                 end,


### PR DESCRIPTION
## Summary

When an ICMP error response (e.g. destination unreachable, TTL exceeded) is received and the destination address embedded in the error packet differs from the address stored in the host list, `ping_loop/3` crashes with a `CaseClauseError`.

This can happen in certain network conditions (e.g. NAT, routing changes, or intermittent connectivity issues). It is a rare edge case, but it should not crash the caller.

### IPv4 ICMP Error handler (line 1359)

`DA` is bound from the error packet's embedded IP header. `lists:keytake/3` finds the host entry by `Seq`, but if the stored address doesn't match `DA`, the first clause fails. Since the only other clause is `false`, this results in a `CaseClauseError`:

```erlang
DA = {DA1, DA2, DA3, DA4},
{Hosts2, Result} =
    case lists:keytake(Seq, 4, Hosts) of
        {value, {ok, Addr, DA, Seq}, NHosts} ->  %% DA is bound — fails if mismatch
            ...;
        false ->                                  %% does not match {value, _, _}
            {Hosts, Acc}
    end,
```

### IPv6 ICMP Error handler (line 1399)

Same issue, plus two additional problems:
- An unconditional pattern match before the `case` that crashes on DA mismatch or when `keytake` returns `false`
- A second `lists:keytake/3` on the original `Hosts` list instead of the updated one

```erlang
{value, {ok, Addr, DA, Seq}, Hosts2} = lists:keytake(Seq, 4, Hosts),  %% crashes here
{Hosts2, Result} =
    case lists:keytake(Seq, 4, Hosts) of  %% should be Hosts2, but entry already removed
```

### Fix

- Add a catch-all clause `{value, _NoMatch, _NHosts} -> {Hosts, Acc}` for both IPv4 and IPv6 ICMP error handlers
- Remove the redundant unconditional match in the IPv6 handler

### Observed error

```
** (CaseClauseError) no case clause matching:
  {:value, {:ok, {x, x, x, x}, {x, x, x, x}, 0}, []}
    gen_icmp.erl:1359: :gen_icmp.ping_loop/3
    gen_icmp.erl:657: :gen_icmp.ping/3
    gen_icmp.erl:504: :gen_icmp.ping/2
```

The error occurred on an embedded device during intermittent connectivity issues. Rare, but the library should handle it gracefully rather than crashing.